### PR TITLE
Amphora v6 Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,27 @@
+version: 2
+general:
+  artifacts:
+    - coverage
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: node:8.10.0
+    working_directory: ~/repo
+    steps:
+      - checkout
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+      - run: npm install
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+      # run tests
+      - run: npm test
+      # send to coveralls
+      - run: cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js

--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,0 @@
-machine:
-  timezone:
-    America/New_York
-  node:
-    version: 8.9.4
-test:
-  post:
-    - cp -r ./coverage/* $CIRCLE_ARTIFACTS
-    - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js

--- a/index.js
+++ b/index.js
@@ -73,11 +73,12 @@ function sanitizeComponent(cmpt) {
  * formats a component for Apple News
  *
  * @param {Object} data
- * @returns {Object} Component rendered for Apple News Format
+ * @param {Object} meta
+ * @param {Object} res
  */
-function render(data, res) {
-  const output = Object.assign({}, _.omit(data._data, ['content', '_ref'])),
-    content = _.get(data, '_data.content') || _.get(data, '_data.components');
+function render(data, meta, res) {
+  const output = Object.assign({}, _.omit(data, ['content', '_ref'])),
+    content = _.get(data, 'content') || _.get(data, 'components'); // TODO: look for any array, not just `content`
   let cmpt;
 
   output.components = [];
@@ -90,9 +91,9 @@ function render(data, res) {
     }
   });
 
-  if (_.get(data, 'locals.query.config', false)) {
-    _.assign(output, getSiteConfig(data.site));
-    output.siteSlug = data.site.slug;
+  if (_.get(meta, 'locals.query.config', false)) {
+    _.assign(output, getSiteConfig(meta.locals.site));
+    output.siteSlug = meta.locals.site.slug;
   }
 
   res.json(output);
@@ -103,4 +104,4 @@ module.exports.render = render;
 // for testing
 module.exports.getSiteConfig = getSiteConfig;
 module.exports.sanitizeComponent = sanitizeComponent;
-module.exports.setLog = (fakeLog) => { log = fakeLog };
+module.exports.setLog = (fakeLog) => { log = fakeLog; };


### PR DESCRIPTION
Renderer's second argument it receives is now an object containing information about the request. The first argument is the composed data _only_. Will update the amphora docs, just needed to test on a component

Also upgrades CircleCI to 2.0 API since it'll be deprecated soon